### PR TITLE
Fix compose translating in wrong direction

### DIFF
--- a/src/main/java/cuchaz/enigma/command/MappingCommandsUtil.java
+++ b/src/main/java/cuchaz/enigma/command/MappingCommandsUtil.java
@@ -66,12 +66,13 @@ public final class MappingCommandsUtil {
         }
 
         if (keepRightOnly) {
+            Translator leftInverseTranslator = new MappingTranslator(invert(left), VoidEntryResolver.INSTANCE);
             for (EntryTreeNode<EntryMapping> node : right) {
                 Entry<?> rightEntry = node.getEntry();
                 EntryMapping rightMapping = node.getValue();
 
                 if (!addedMappings.contains(rightEntry)) {
-                    result.insert(leftTranslator.translate(rightEntry), rightMapping);
+                    result.insert(leftInverseTranslator.translate(rightEntry), rightMapping);
                 }
             }
         }


### PR DESCRIPTION
I accidentally reversed what the compose command does in my last PR since I was testing it on the wrong file. This fixes that.